### PR TITLE
Improve Bitwarden secret fetching error handling

### DIFF
--- a/src/acme_utils/bitwarden.py
+++ b/src/acme_utils/bitwarden.py
@@ -1,6 +1,9 @@
 import subprocess
 import os
 import json
+import logging
+
+logger = logging.getLogger(__name__)
 
 # ===== シークレット情報の取得 =====
 def get_secret_from_bitwarden(secret_name: str) -> str:
@@ -8,13 +11,30 @@ def get_secret_from_bitwarden(secret_name: str) -> str:
     access_token = os.getenv("BWS_ACCESS_TOKEN")
     if access_token is None:
         raise RuntimeError("BWS_ACCESS_TOKEN environment variable is not set.")
-    result = subprocess.run(
-        ["bws", "secret", "get", secret_name, "--access-token", access_token],
-        capture_output=True,
-        text=True,
-        encoding="utf-8",
-        check=True
-    )
-    secret_json = json.loads(result.stdout)
+    try:
+        result = subprocess.run(
+            ["bws", "secret", "get", secret_name, "--access-token", access_token],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            check=True,
+        )
+    except subprocess.CalledProcessError as exc:
+        logger.error("Bitwarden CLI failed: %s", exc.stderr.strip() if exc.stderr else exc)
+        raise RuntimeError(
+            f"Failed to retrieve secret '{secret_name}' from Bitwarden"
+        ) from exc
+
+    try:
+        secret_json = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        logger.error(
+            "Invalid JSON output for secret '%s': %s",
+            secret_name,
+            exc.msg,
+        )
+        raise RuntimeError(
+            f"Bitwarden returned invalid JSON for secret '{secret_name}'"
+        ) from exc
     return secret_json["value"]
 


### PR DESCRIPTION
## Summary
- add logging and robust error handling when invoking bws CLI
- handle malformed JSON responses from Bitwarden

## Testing
- `python -m py_compile src/acme_utils/bitwarden.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689bff40f248832d925d463a2374ea3b