### PR TITLE
Add README to MANIFEST for sdist packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,3 @@
-include LICENSE
+include LICENSE README.md
+
+# Include additional non-Python files as needed


### PR DESCRIPTION
## Summary
- include README.md in MANIFEST to ensure it's packaged with the sdist
- note that additional non-Python resources should be listed as needed

## Testing
- `python -m build` *(fails: No module named build)*

------
https://chatgpt.com/codex/tasks/task_e_689d4c174e1c832d84b97c6b82490cab