### PR TITLE
fix: configure GPG secrets in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      GPG_PRIVATE_KEY: ${{ secrets.GPG_PRIVATE_KEY }}
+      GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -29,14 +32,14 @@ jobs:
         run: python -m build
 
       - name: Import GPG key
-        if: secrets.GPG_PRIVATE_KEY != ''
+        if: ${{ env.GPG_PRIVATE_KEY != '' }}
         uses: crazy-max/ghaction-import-gpg@v6
         with:
-          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
-          passphrase: ${{ secrets.GPG_PASSPHRASE }}
+          gpg_private_key: ${{ env.GPG_PRIVATE_KEY }}
+          passphrase: ${{ env.GPG_PASSPHRASE }}
 
       - name: Sign artifacts
-        if: secrets.GPG_PRIVATE_KEY != ''
+        if: ${{ env.GPG_PRIVATE_KEY != '' }}
         run: |
           for dist in dist/*; do
             gpg --batch --yes --detach-sign --armor "$dist"


### PR DESCRIPTION
## Summary
- configure GPG secrets as job env vars to allow conditional execution

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689d6c7d6dc0832da112a92ac387f1e3