### PR TITLE
Limit release workflow to version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
 
 jobs:
   release:


### PR DESCRIPTION
## Summary
- Restrict release workflow to run only on pushes of tags starting with `v`

## Testing
- `python -m pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_689d76985c34832d90b864955a20d529