### PR TITLE
Add smoke test to exercise package import

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,0 +1,11 @@
+import importlib
+import sys
+from pathlib import Path
+
+
+def test_package_import(monkeypatch):
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/bws")
+    monkeypatch.setattr("importlib.metadata.version", lambda name: "0.0")
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+    acme_utils = importlib.import_module("acme_utils")
+    assert isinstance(acme_utils.__version__, str)


### PR DESCRIPTION
## Summary
- add minimal smoke test that patches dependency checks and imports package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689d9c859818832d82f96c2e48fdf65c