### PR TITLE
chore: use uv in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,18 +31,23 @@ jobs:
         with:
           python-version: ${{ github.event.inputs.python-version || '3.x' }}
 
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v1
+
+      - name: Set up virtual environment
+        run: uv venv
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-          python -m pip install build pytest
+          if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+          uv pip install build pytest
 
       - name: Run tests
         run: |
-          if [ -d tests ]; then python -m pytest; else echo 'No tests to run'; fi
+          if [ -d tests ]; then uv run pytest; else echo 'No tests to run'; fi
 
       - name: Build distributions
-        run: python -m build
+        run: uv run python -m build
 
       - name: Install cosign
         uses: sigstore/cosign-installer@v3


### PR DESCRIPTION
## Summary
- replace pip with uv in release workflow

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8552ec6f0832d8af94e7d970ddcce