### PR TITLE
chore: handle pyproject dependencies in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,11 @@ jobs:
 
       - name: Install dependencies
         run: |
-          if [ -f requirements.txt ]; then uv pip install -r requirements.txt; fi
+          if [ -f requirements.txt ]; then
+            uv pip install -r requirements.txt
+          elif [ -f pyproject.toml ]; then
+            uv pip install -e .
+          fi
           uv pip install build pytest
 
       - name: Run tests


### PR DESCRIPTION
## Summary
- support installing dependencies from pyproject-based projects in release workflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a857019a20832d9df3d2b6e9eac0de